### PR TITLE
poplar_recovery_builder: Fix cleanup

### DIFF
--- a/poplar_recovery_builder.sh
+++ b/poplar_recovery_builder.sh
@@ -75,7 +75,7 @@ function suser_append() {
 
 function cleanup() {
 	[ "${LOOP_MOUNTED}" ] && sudo umount ${LOOP}
-	rm -rf ${MOUNT}
+	sudo rm -rf ${MOUNT}
 	[ "${LOOP_ATTACHED}" ] && loop_detach
 	rm -f ${LOADER}
 	rm -f ${IMAGE}


### PR DESCRIPTION
The rootfs tarball was extracted using sudo.
Address a permissions error by using sudo rm.

Signed-off-by: Andreas Färber <afaerber@suse.de>