### PR TITLE
poplar_recovery_builder.sh: Remove --no-tell-kernel sfdisk argument

### DIFF
--- a/build_instructions.md
+++ b/build_instructions.md
@@ -342,7 +342,7 @@ package a USB recovery device. These instructions assume you are using Linux bas
 
   The files required for partitioning and re-flashing the content of
   eMMC media on the Poplar board were produced earlier, and should
-  not be present in ~tftp/recovery_files.  The Ethernet interface on
+  now be present in ~tftp/recovery_files.  The Ethernet interface on
   the Poplar board must be configured, and then an installer script
   will be downloaded and executed.
 

--- a/poplar_recovery_builder.sh
+++ b/poplar_recovery_builder.sh
@@ -418,7 +418,7 @@ function disk_partition() {
 			echo ""
 		done
 		echo "write"
-	} | sfdisk --quiet --no-reread --no-tell-kernel ${TEMPFILE}
+	} | sfdisk --quiet --no-reread ${TEMPFILE}
 }
 
 function fstab_init() {


### PR DESCRIPTION
This argument is neither portable between distros nor useful when
sfdisk is running, as it is here, on a file rather than on a device.

Fixes: 0e70ff4 ("poplar_recovery_builder.sh: switch to new Ethernet version")
Signed-off-by: Victor Chong <victor.chong@linaro.org>